### PR TITLE
Issue #73 Run Reports with a Filtered Tag

### DIFF
--- a/template/summary.erb
+++ b/template/summary.erb
@@ -5,6 +5,9 @@
     <th>Scenario</th>
     <th class="hide">Tags</th>
     <th>Status</th>
+    <% if options[:tag_filter] %>
+        <th class="hide-on-small-only">Filtered Tags</th>
+    <% end %>
     <th class="hide-on-small-only">Error</th>
   </tr>
   </thead>

--- a/template/summary_row.erb
+++ b/template/summary_row.erb
@@ -18,6 +18,16 @@
   <%= scenario['status'] %>
 </td>
 
+<% if options[:tag_filter] %>
+    <td class="hide-on-small-only">
+      <% scenario['tags'].each do |tag| %>
+          <% if tag['name'].match(/#{options[:tag_filter]}/) %>
+              <%= tag['name'] %>
+          <% end %>
+      <% end %>
+    </td>
+<% end %>
+
 <td class="hide-on-small-only">
   <% if scenario['error'] %>
       <%= scenario['error'] %>


### PR DESCRIPTION
Add in a way to pass in a tag to filter on through options hash.  This will allow users to find and show only one unique tag.  For example if all of a reports unique tags start with unq_XXX you can pass in unq and it will filter on and show those tags only.

