### PR TITLE
Fix cli info option

### DIFF
--- a/bin/report_builder
+++ b/bin/report_builder
@@ -50,8 +50,9 @@ opt_parser = OptionParser.new do |opts|
   end
 
   opts.on('-I', '--info a:x,b:y,c:z', Array, 'List of additional info') do |list|
+    options[:additional_info] = { }
     list.each do |i|
-      key, value = i.split(':')
+      key, value = i.split(':', 2)
       options[:additional_info][key] = value
     end
   end


### PR DESCRIPTION
This PR fixes two problems with --info/-I option.

### First: Fix an error

I ran the following command:

```
bundle exec report_builder -s foo.json -o foo --info foo:bar
```

it fails with an error:

```
~/myproj # bundle exec report_builder --version
ReportBuilder v1.8
~/myproj # bundle exec report_builder -s foo.json -o foo --info foo:bar
bundler: failed to load command: report_builder (/usr/local/bundle/bin/report_builder)
NoMethodError: undefined method `[]=' for nil:NilClass
  /usr/local/bundle/gems/report_builder-1.8/bin/report_builder:55:in `block (3 levels) in <top (required)>'
  /usr/local/bundle/gems/report_builder-1.8/bin/report_builder:53:in `each'
  /usr/local/bundle/gems/report_builder-1.8/bin/report_builder:53:in `block (2 levels) in <top (required)>'
  /usr/local/lib/ruby/2.6.0/optparse.rb:1582:in `block in parse_in_order'
  /usr/local/lib/ruby/2.6.0/optparse.rb:1568:in `catch'
  /usr/local/lib/ruby/2.6.0/optparse.rb:1568:in `parse_in_order'
  /usr/local/lib/ruby/2.6.0/optparse.rb:1562:in `order!'
  /usr/local/lib/ruby/2.6.0/optparse.rb:1656:in `permute!'
  /usr/local/lib/ruby/2.6.0/optparse.rb:1678:in `parse!'
  /usr/local/bundle/gems/report_builder-1.8/bin/report_builder:80:in `<top (required)>'
  /usr/local/bundle/bin/report_builder:23:in `load'
  /usr/local/bundle/bin/report_builder:23:in `<top (required)>'
```

### Second: Use of messages containing colons

I want to set a message including a colon such as date format.

Example:

```
bundle exec report_builder -s foo.json -o foo --info "StartedAt:2019-04-16 12:00:00"
```

Expected:

| StartedAt | 2019-04-16 12:00:00 |

Actual:

| StartedAt | 2019-04-16 12 |
