### PR TITLE
Add feature file sorting

### DIFF
--- a/lib/report_builder/builder.rb
+++ b/lib/report_builder/builder.rb
@@ -80,6 +80,11 @@ module ReportBuilder
         raise "Error:: No file(s) found at #{input_path}" if files.empty?
         groups << {'features' => get_features(files)}
       end
+      groups.each do |this_group|
+        this_group['features'].each do |feature|
+          feature['elements'] = feature['elements'].sort_by { |v| v['line']}
+        end
+      end
       groups
     end
 


### PR DESCRIPTION
I use this gem to generate reports from JSON files that were written by `parallel_tests`, which splits out scenarios by example across separate processes. The resulting report correctly groups scenarios by feature file, but the examples therein aren't sorted. This PR will sort each feature file by line number so that the resulting report is tidy. 