### PR TITLE
Reported text with indentation

### DIFF
--- a/lib/report_builder/builder.rb
+++ b/lib/report_builder/builder.rb
@@ -39,7 +39,7 @@ module ReportBuilder
       html_report_path = options[:html_report_path] || options[:report_path]
       if options[:report_types].include? 'HTML'
         File.open(html_report_path + '.html', 'w') do |file|
-          file.write get(groups.size > 1 ? 'group_report' : 'report').result(binding).gsub('  ', '').gsub("\n\n", '')
+          file.write get(groups.size > 1 ? 'group_report' : 'report').result(binding)
         end
       end
 


### PR DESCRIPTION
Multiple spaces and newlines are often used to created indentation in reported text blocks. Replacing them with a single space/newline as it was by now breaks it.