### PR TITLE
issue-83 enabling grouped report through CLI

### DIFF
--- a/bin/report_builder
+++ b/bin/report_builder
@@ -13,6 +13,14 @@ opt_parser = OptionParser.new do |opts|
     options[:input_path] = list
   end
 
+  opts.on('-g', '--groups a:x,b:y,c:z', Array, 'List of grouped feature mappings') do |list|
+    options[:json_path] = { }
+    list.each do |i|
+      key, value = i.split(':', 2)
+      options[:json_path][key] = value
+    end
+  end
+
   opts.on('-o', '--out [PATH]NAME', String, 'Report path with name without extension') do |report_path|
     options[:report_path] = report_path
   end


### PR DESCRIPTION
added CLI arg option to achieve grouped features report through CLI, the string that works is of the following format:
`key1:value1, key2:value2, key3:value3...`
Tested for couple of different inputs and works fine.