### PR TITLE
Use params for ERB.new per deprecation warning

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@ version: '1.0.{build}'
 
 environment:
   matrix:
-    - RUBY_VERSION: 23
-    - RUBY_VERSION: 23-x64
-    - RUBY_VERSION: 25
+    - RUBY_VERSION: 27
+    - RUBY_VERSION: 27-x64
+    - RUBY_VERSION: 31
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%

--- a/lib/report_builder/builder.rb
+++ b/lib/report_builder/builder.rb
@@ -64,7 +64,7 @@ module ReportBuilder
 
     def get(template)
       @erb ||= {}
-      @erb[template] ||= ERB.new(File.read(File.dirname(__FILE__) + '/../../template/' + template + '.erb'), nil, nil, '_' + template)
+      @erb[template] ||= ERB.new(File.read(File.dirname(__FILE__) + '/../../template/' + template + '.erb'), eoutvar: '_' + template)
     end
 
     def get_groups(input_path)


### PR DESCRIPTION
Ruby 3.1 is throwing these deprecation warnings for `ERB.new`. 
```
gems/report_builder-1.9/lib/report_builder/builder.rb:67: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
gems/report_builder-1.9/lib/report_builder/builder.rb:67: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
gems/report_builder-1.9/lib/report_builder/builder.rb:67: warning: Passing eoutvar with the 4th argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, eoutvar: ...) instead.
```
This uses the `eoutvar` param (as the other params are `nil`) to rectify. I ran the specs in ruby 2.7 and 3.1 and they both passed. If you believe there should be other tests added please let me know, but I think this private method gets covered in the existing tests
